### PR TITLE
Don't expose handlers "inProgess" property to window object.

### DIFF
--- a/js/jquery.terminal-0.4.17.js
+++ b/js/jquery.terminal-0.4.17.js
@@ -233,15 +233,15 @@ function get_stack(caller) {
                 fn.$timerID = fn.$timerID || this.guid++;
 
                 var handler = function() {
-                    if (belay && this.inProgress) {
+                    if (belay && handler.inProgress) {
                         return;
                     }
-                    this.inProgress = true;
+                    handler.inProgress = true;
                     if ((++counter > times && times !== 0) ||
                         fn.call(element, counter) === false) {
                         jQuery.timer.remove(element, label, fn);
                     }
-                    this.inProgress = false;
+                    handler.inProgress = false;
                 };
 
                 handler.$timerID = fn.$timerID;


### PR DESCRIPTION
The window.setInterval() provides the window object as this reference to handler(). So this.inProgress points to window.inProgress and the property gets exposed.
Prevent that by using "handler" instead of "this".
