### PR TITLE
Allow shortcut for browser window switching on Mac

### DIFF
--- a/js/jquery.terminal-0.6.3.js
+++ b/js/jquery.terminal-0.6.3.js
@@ -1082,6 +1082,9 @@
                     paste();
                     return true;
                 } else if (e.ctrlKey || e.metaKey) {
+                    if (e.which === 192) { // CMD+` switch browser window on Mac
+                        return true;
+                    }
                     if (e.shiftKey) { // CTRL+SHIFT+??
                         if (e.which === 84) {
                             //CTRL+SHIFT+T open closed tab


### PR DESCRIPTION
On Mac, CMD + ` is the shortcut to switch between the open windows of the same application.

The terminal currently doesn't support this, and it does break the flow a lot - I can use the keyboard to switch between all browser windows, but not from one which contains focused jquery.terminal.

Thanks.
