### PR TITLE
Added raw HTML output.

### DIFF
--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -28,7 +28,7 @@
 /*
 
      TODO:
-           add destroy method to terminal (cmd alrady have it)
+           add destroy method to terminal (cmd already has it)
 
           distinguish between paused and disabled
           paused should block keydown in terminal it should disable command line
@@ -1812,6 +1812,15 @@
         function draw_line(string) {
             string = typeof string === 'string' ? string : String(string);
             var div, i, len;
+
+	    // Early exit if we are allowing raw HTML output and this string begins
+	    // with settings.htmlRawPrefix
+	    if(settings.htmlRaw && 
+	       string.substring(0,settings.htmlRawPrefix.length) === settings.htmlRawPrefix)
+	    {
+		return draw_html(string);
+	    }
+
             if (string.length > num_chars || string.match(/\n/)) {
                 // string can have line break
                 //var array = string.split('\n');
@@ -1834,6 +1843,14 @@
             scroll_to_bottom();
             return div;
         }
+
+	function draw_html(string) {
+	    var div = $('<div/>').html('<div>' + string + '</div>');
+	    output.append(div);
+	    div.width('100%');
+	    scroll_to_bottom();
+	    return div;
+	}
 
         function show_greetings() {
             if (settings.greetings === undefined) {
@@ -2324,6 +2341,8 @@
                 displayExceptions: true,
                 cancelableAjax: true,
                 processArguments: true,
+		htmlRaw: false,
+		htmlRawPrefix: '<!--HTMLRAW-->',
                 login: null,
                 tabcompletion: null,
                 historyFilter: null,


### PR DESCRIPTION
 To enable, add `htmlRaw: true` to the settings, and start strings with `settings.htmlRawPrefix` (by default this is `<!--HTMLRAW-->`).

This is useful for providing a shell that also allows HTML output from the interpreter.
That HTML output can interact with the shell or link to other functions.

While ascii formatting requires interpretation to translate to CSS, raw HTML only needs a marker at the beginning of the "line" to indicate that the line's <div/> should contain raw HTML. In this case, an HTML comment works and does not need to be removed from the string. The default HTML comment is "<!--HTMLRAW-->" but the user can change this in the settings.

Its kind of cool to "echo" raw html and get images, tables, and buttons in the "shell"!
