### PR TITLE
Making greetings option actually allow function instead of string

### DIFF
--- a/js/jquery.terminal-0.7.5.js
+++ b/js/jquery.terminal-0.7.5.js
@@ -2548,7 +2548,14 @@
             if (settings.greetings === undefined) {
                 self.echo(self.signature);
             } else if (settings.greetings) {
-                self.echo(settings.greetings);
+                switch(typeof settings.greetings){
+                    switch 'string':
+                        self.echo(settings.greetings);
+                        break;
+                    switch 'function':
+                        settings.greetings(self.echo);
+                        break;
+                }
             }
         }
         // -----------------------------------------------------------------------


### PR DESCRIPTION
In the docs it says: 
greetings [string|function(callback)] — default is set to JQuery Terminal Singnature. You can set it to string or function (like prompt) with callback argument which must be called with your string.

I just added the code that allowed you to use a callback.
