### PR TITLE
If the command line is hidden, don't accept input.

### DIFF
--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -953,7 +953,7 @@
                     return result;
                 }
             }
-            if (enabled) {
+            if (enabled && self.css('visibility') !== 'hidden') {
                 var pos, len, result;
                 if (e.which !== 38 &&
                     !(e.which === 80 && e.ctrlKey)) {


### PR DESCRIPTION
Whenever a user types something, I use an AJAX call to get the information they need. The command line would be visible and then the data would squeeze between the command line and my last entered command. So I just hid the command line by `$('.cmd').css('visibility', 'hidden');`. Then once I get my data back, I show the command line again. Even though it was invisible, the user could still type commands. Adding this simple check makes this terminal AJAX friendly.
