### PR TITLE
fixed Makefile: there's no www/ any more

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ JSC=java -jar bin/closure.bin/compiler.jar --js
 SED=sed
 CP=cp
 
-ALL: js/jquery.terminal-$(VERSION).js js/jquery.terminal-$(VERSION).min.js js/jquery.terminal-min.js README.md www/Makefile terminal.jquery.json
+ALL: js/jquery.terminal-$(VERSION).js js/jquery.terminal-$(VERSION).min.js js/jquery.terminal-min.js README.md terminal.jquery.json
 
 js/jquery.terminal-$(VERSION).js: js/jquery.terminal-src.js .$(VERSION)
 	$(SED) -e "s/{{VER}}/$(VERSION)/g" -e "s/{{DATE}}/`date -uR`/g" js/jquery.terminal-src.js > js/jquery.terminal-$(VERSION).js
@@ -23,5 +23,7 @@ README.md: README.in .$(VERSION)
 terminal.jquery.json: manifest .$(VERSION)
 	$(SED) -e "s/{{VER}}/$(VERSION)/g" manifest > terminal.jquery.json
 
-www/Makefile: Makefile
-	$(SED) -e "s/{{VERSION}}/$(VERSION)/g" www/Makefile.in > www/Makefile
+clean:
+	-rm -f js/jquery.terminal-0.*.js js/jquery.terminal-0.*.min.js js/jquery.terminal.js js/jquery.terminal.min.js js/jquery.terminal-min.js README.md terminal.jquery.json
+
+.PHONY: ALL clean


### PR DESCRIPTION
Makefile now also includes a 'clean' target and the .PHONY targets are listed as such
