### PR TITLE
Stray [0m should do nothing

### DIFF
--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -2096,8 +2096,6 @@
                             }
                             if (match[1] !== '0') {
                                 code = format_ansi(match[1]);
-                            } else {
-                                code = ['', ''];
                             }
                             if (inside) {
                                 output.push(']');
@@ -2119,14 +2117,16 @@
                                     }
                                 }
                             } else {
-                                inside = true;
-                                output.push('[[' + code.join(';') + ']');
-                                // store colors to next use
-                                if (code[1]) {
-                                    prev_color = code[1];
-                                }
-                                if (code[2]) {
-                                    prev_background = code[2];
+                                if (match[1] != '0') {
+                                    inside = true;
+                                    output.push('[[' + code.join(';') + ']');
+                                    // store colors to next use
+                                    if (code[1]) {
+                                        prev_color = code[1];
+                                    }
+                                    if (code[2]) {
+                                        prev_background = code[2];
+                                    }
                                 }
                             }
                             break;


### PR DESCRIPTION
Consider output from `ipython -c 'x'`. Currently `jquery.terminal` renders it with garbage on lines 4, 5:

```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
<ipython-input-12-401b30e3b8b5> in <module>()
----> 1 x[[;]
]
NameError: name 'x' is not defined
```

This boils down to stray `[0m`, e.g. compare `\033[31mx\033[0my` and `\033[31mx\033[0my\033[0mz`.
