### PR TITLE
Fix pasting multiple lines containing tabs.

### DIFF
--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -1008,13 +1008,13 @@
                             lines_after(array.slice(2));
                         } else {
                             var last = array.slice(-1)[0];
-                            var from_last = string.length - position;
+                            var from_last = string.length - position - tabs_rm;
                             var last_len = last.length;
                             var pos = 0;
                             if (from_last <= last_len) {
                                 lines_before(array.slice(0, -1));
                                 pos = last_len === from_last ? 0 : last_len-from_last;
-                                draw_cursor_line(last, pos+tabs_rm);
+                                draw_cursor_line(last, pos);
                             } else {
                                 // in the middle
                                 if (num_lines === 3) {


### PR DESCRIPTION
An example of what this fixes is pasting "\ta\nb"

The tabs_rm needs to be taken into account when doing the check on line 1014 otherwise it will drop into the code for the cursor being in the middle when it should be at the end.
