### PR TITLE
fixes jcubic/jquery.terminal#225 line width is wrong on small screens

### DIFF
--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -2502,7 +2502,7 @@
     // :: calculate numbers of characters
     // -----------------------------------------------------------------------
     function get_num_chars(terminal) {
-        var temp = $('<div class="terminal wrap"><span class="cursor">' +
+        var temp = $('<div class="terminal"><span class="cursor">' +
                      '</span></div>').appendTo('body').css('padding', 0);
         var span = temp.find('span');
         // use more characters to get width of single character as a fraction


### PR DESCRIPTION
The problem here is that the span used to calculate line width is actually _wrapping_ on a small screen. So when the character width is calculated, we think all the characters fit. Removing the css class resolves the issue, but it was put there to fix a wrapping issue in  jcubic/jquery.terminal#183, so you may want to make sure this is the right way to fix the issue.