### PR TITLE
Removed the git conflict markers in the source, accepting the HEAD code

### DIFF
--- a/examples/rpc-demo.html
+++ b/examples/rpc-demo.html
@@ -7,11 +7,8 @@
     <meta name="Description" content="Demonstration for JQuery Terminal Emulator using call automaticly JSON-RPC service (in php) with authentication."/>
     <script src="../js/jquery-1.7.1.min.js"></script>
     <script src="../js/jquery.mousewheel-min.js"></script>
-<<<<<<< HEAD
     <script src="../js/jquery.terminal-src.js"></script>
-=======
     <script src="../js/jquery.terminal.min.js"></script>
->>>>>>> master
     <link href="../css/jquery.terminal.css" rel="stylesheet"/>
     <script>
     jQuery(document).ready(function($) {


### PR DESCRIPTION
I just found that there are still a git conflict markers left in the _rpc-demo.html_ file. I just made an adjustment to accepts the **HEAD**'s piece of code. If that's what you want, feel free to just pull it, or you could do it yourself. Just a heads up. Thanks for your work.
