### PR TITLE
Patch for enabled:false not working on init

### DIFF
--- a/js/jquery.terminal-1.0.1.js
+++ b/js/jquery.terminal-1.0.1.js
@@ -3804,7 +3804,7 @@
                     // throw e; // it will be catched by terminal
                 } finally {
                     onPause = $.noop;
-                    if (!was_paused) {
+                    if (!was_paused && self.enabled()) {
                         // resume login if user didn't call pause in onInit
                         // if user pause in onInit wait with exec until it
                         // resume

--- a/js/jquery.terminal-1.0.1.js
+++ b/js/jquery.terminal-1.0.1.js
@@ -5164,7 +5164,7 @@
                         } else {
                             init();
                         }
-                        if (!was_paused) {
+                        if (!was_paused && self.enabled()) {
                             self.resume();
                         }
                     });


### PR DESCRIPTION
Having ```enabled: false``` on initialization has no effect and the terminal starts focused accepting input.
I did not test all possible scenarios.