### PR TITLE
add Consolas font-family for windows

### DIFF
--- a/css/jquery.terminal-src.css
+++ b/css/jquery.terminal-src.css
@@ -138,7 +138,7 @@ body.terminal {
     float: left;
 }
 .terminal, .cmd {
-    font-family: monospace;
+    font-family: Consolas,monospace;
     /*font-family: FreeMono, monospace; this don't work on Android */
     color: #aaa;
     background-color: #000;


### PR DESCRIPTION
<!--

Thank you the PR, if you want your PR to be merged make sure you modify -src files and run make to build
the project (it add date+version and minify the files) and create PR against devel branch

-->

i dont have the development environment, so i can not run make to  build the project. but it is just one line changed. 

"monospace" works well on my macbook, but on windows "Consolas" is better .

before i add Consolas font-family, an example on chrome on windows:
![_20180407074021](https://user-images.githubusercontent.com/9766872/38448500-1f041756-3a37-11e8-9ac1-3146fe26c4d7.png)

after that:
![_20180407074047](https://user-images.githubusercontent.com/9766872/38448502-25dd199c-3a37-11e8-94f1-ac49de10ccb6.png)






