### PR TITLE
Use css variable for `.error` or fallback to red

### DIFF
--- a/css/jquery.terminal-src.css
+++ b/css/jquery.terminal-src.css
@@ -244,6 +244,7 @@ terminal .terminal-output > div {
 }
 .terminal .terminal-output div.error, .terminal .terminal-output div.error div {
     color: red;
+    color: var(--error-color, red);
 }
 .tilda {
     position: fixed;

--- a/css/jquery.terminal.css
+++ b/css/jquery.terminal.css
@@ -244,6 +244,7 @@ terminal .terminal-output > div {
 }
 .terminal .terminal-output div.error, .terminal .terminal-output div.error div {
     color: red;
+    color: var(--error-color, red);
 }
 .tilda {
     position: fixed;


### PR DESCRIPTION
I added a small bit of CSS which will allow us to specify the `--error-color` the same way we can specify `--link-color`.

I currently do this:
```
.cmder--terminal .error, .cmder--terminal .error div {
    color: var(--error-color) !important;
}
```

which is not the most ellegant way.

<sub>Oh BTW, sorry I couldn't run `make` before comitting, the `uglifyjs` binary kept spitting Error 137, which I couldn't figure out how to resolve.</sub>