### PR TITLE
help uses same procs as interpreter

### DIFF
--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -5720,7 +5720,7 @@
                     var login = typeof auth === 'string' ? auth : 'login';
                     interpreter_object.help = interpreter_object.help || function(fn) {
                         if (typeof fn === 'undefined') {
-                            var names = response.procs.map(function(proc) {
+                            var names = procs.map(function(proc) {
                                 return proc.name;
                             }).join(', ') + ', help';
                             self.echo('Available commands: ' + names);


### PR DESCRIPTION
Having rpc procs at result.procs can function by setting describe, but the automatic help function is still looking at procs. Just changed to look in the same spot.