### PR TITLE
Typings - add s to parse_option function

### DIFF
--- a/js/jquery.terminal.d.ts
+++ b/js/jquery.terminal.d.ts
@@ -313,7 +313,7 @@ interface JQueryTerminalStatic {
     split_arguments(str: string): string[];
     parse_command(str: string): JQueryTerminal.ParsedCommand<number | RegExp | string>;
     split_command(str: string): JQueryTerminal.ParsedCommand<string>;
-    parse_option(arg: string | string[], options?: { booleans: string[] }): JQueryTerminal.ParsedOptions;
+    parse_options(arg: string | string[], options?: { booleans: string[] }): JQueryTerminal.ParsedOptions;
     extended_command(term: JQueryTerminal, str: string): void;
     /**
      * formatter is an object that can be used in RegExp functions


### PR DESCRIPTION
The Typescript file contains a parse_option function but it should be parse_options (with an s)