### PR TITLE
Bugfix when supplying a function to `greetings` option of Terminal instance.

### DIFF
--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -6672,7 +6672,7 @@
                     self.echo(settings.greetings);
                 } else if (type === 'function') {
                     try {
-                        settings.greetings.call(self, self.echo);
+                        settings.greetings.call(this, self, self.echo);
                     } catch (e) {
                         settings.greetings = null;
                         display_exception(e, 'greetings');


### PR DESCRIPTION
According the TypeScript `.d.ts` file, when supplying a function to `greetings` option of Terminal instance, it should be as 

```typescript
(this: JQueryTerminal, setGreeting: setEchoValueFunction) => void
```

And following the [documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/call), there should be explicitly a `this` argument when calling a function with `.call` method.

So, the line should rather be

```diff
- settings.greetings.call(self, self.echo);
+ settings.greetings.call(this, self, self.echo);
```