### PR TITLE
Devel

### DIFF
--- a/examples/json-rpc.php
+++ b/examples/json-rpc.php
@@ -258,9 +258,10 @@ function handle_json_rpc($object) {
             } else {
                 $method_object = new ReflectionMethod($class, $method);
                 $num_got = count($params);
-                $num_expect = $method_object->getNumberOfRequiredParameters();
-                if ($num_got != $num_expect) {
-                    $msg = "Wrong number of parameters. Got $num_got expect $num_expect";
+                $num_min = $method_object->getNumberOfRequiredParameters();
+                $num_max = $method_object->getNumberOfParameters();
+                if ($num_got < $num_min  || $num_got > $num_max) {
+                    $msg = "Wrong number of parameters. Got $num_got expected between $num_min and $num_max";
                     throw new JsonRpcExeption(105, $msg);
                 } else {
                     //throw new Exception('x -> ' . json_encode($params));

--- a/examples/json-rpc.php
+++ b/examples/json-rpc.php
@@ -258,7 +258,7 @@ function handle_json_rpc($object) {
             } else {
                 $method_object = new ReflectionMethod($class, $method);
                 $num_got = count($params);
-                $num_expect = $method_object->getNumberOfParameters();
+                $num_expect = $method_object->getNumberOfRequiredParameters();
                 if ($num_got != $num_expect) {
                     $msg = "Wrong number of parameters. Got $num_got expect $num_expect";
                     throw new JsonRpcExeption(105, $msg);


### PR DESCRIPTION
Changed to get number of required parameters as well, to be able to call methods with optional arguments

Changed code in json-rpc.php
~~~
$method_object = new ReflectionMethod($class, $method);
$num_got = count($params);
$num_min = $method_object->getNumberOfRequiredParameters();
$num_max = $method_object->getNumberOfParameters();
if ($num_got < $num_min  || $num_got > $num_max) {
    $msg = "Wrong number of parameters. Got $num_got expected between $num_min and $num_max";
    throw new JsonRpcExeption(105, $msg);
} else {
    //throw new Exception('x -> ' . json_encode($params));
    $result = call_user_func_array(array($object, $method), $params);
    echo response($result, $id, null);
}
~~~

**WORKING EXAMPLE BELOW**

Example PHP method in rpc.php
~~~
public function optional($token, $required, $optional = 'null'){
    return 'Required: ' . $required . ', Optional: ' . $optional;
}
~~~

Test before changes
~~~
> optional someValue
[RPC] Wrong number of parameters. Got 2 expect 3
~~~

Test after changes
~~~
> optional
[RPC] Wrong number of parameters. Got 1 expected between 2 and 3

> optional someValue
Required: someValue, Optional: null

> optional someValue anotherValue
Required: someValue, Optional: anotherValue

> optional someValue anotherValue aThirdValue
[RPC] Wrong number of parameters. Got 4 expected between 2 and 3
~~~

Although if checkArity is TRUE, it still will throw an error
~~~
> optional someValue
[Arity] Wrong number of arguments. Function 'optional' expects 3 got 2!
~~~
This will probably need some modifications in the JS file


