### PR TITLE
Add a monkey patch for set_prompt in echo_newline.js

### DIFF
--- a/__tests__/terminal.spec.js
+++ b/__tests__/terminal.spec.js
@@ -2673,6 +2673,22 @@ describe('extensions', function() {
             expect(term.get_output()).toEqual('...' + prompt2 + command);
             expect(term.get_prompt()).toEqual(prompt2);
         });
+        it("set_prompt with a function for the prompt", function(){
+            var prompt1 = (cb) => cb('>>> ');
+            var prompt2 = (cb) => cb('~~~ ');
+            var command = 'hello';
+            term.set_prompt(prompt1);
+            term.echo('.', {newline: false});
+            expect(term.get_prompt()).toEqual(prompt1);
+            term.echo('.', {newline: false});
+            expect(term.get_prompt()).toEqual(prompt1);
+            term.set_prompt(prompt2);
+            term.echo('.', {newline: false});
+            expect(term.get_prompt()).toEqual(prompt2);
+            enter(term, command);
+            expect(term.get_output()).toEqual('...' + prompt2 + command);
+            expect(term.get_prompt()).toEqual(prompt2);
+        });
     });
     describe('autocomplete_menu', function() {
         function completion(term) {

--- a/__tests__/terminal.spec.js
+++ b/__tests__/terminal.spec.js
@@ -2657,6 +2657,22 @@ describe('extensions', function() {
             expect(term.get_output()).toEqual('...' + prompt + command);
             expect(term.get_prompt()).toEqual(prompt);
         });
+        it('get_prompt and set_prompt work as expected', function() {
+            var prompt1 = '>>> ';
+            var prompt2 = '~~~ ';
+            var command = 'hello';
+            term.set_prompt(prompt1);
+            term.echo('.', {newline: false});
+            expect(term.get_prompt()).toEqual(prompt1);
+            term.echo('.', {newline: false});
+            expect(term.get_prompt()).toEqual(prompt1);
+            term.set_prompt(prompt2);
+            term.echo('.', {newline: false});
+            expect(term.get_prompt()).toEqual(prompt2);
+            enter(term, command);
+            expect(term.get_output()).toEqual('...' + prompt2 + command);
+            expect(term.get_prompt()).toEqual(prompt2);
+        });
     });
     describe('autocomplete_menu', function() {
         function completion(term) {

--- a/js/echo_newline.js
+++ b/js/echo_newline.js
@@ -151,7 +151,7 @@
             term.__set_prompt((last || "") + prompt);
         };
         term.get_prompt = function() {
-            return last ? prompt : term.__get_prompt();
+            return last !== null ? prompt : term.__get_prompt();
         };
     }
 });

--- a/js/echo_newline.js
+++ b/js/echo_newline.js
@@ -94,6 +94,7 @@
         term.__echo = term.echo;
         term.__exec = term.exec;
         term.__set_prompt = term.set_prompt;
+        term.__get_prompt = term.get_prompt;
         term.exec = function() {
             last = null;
             if (echo_command) {
@@ -148,5 +149,12 @@
             prompt = new_prompt;
             term.__set_prompt((last || "") + prompt);
         };
+        term.get_prompt = function(){
+            if(last === null){
+                return term.__get_prompt();
+            } else {
+                return prompt;
+            }
+        }
     }
 });

--- a/js/echo_newline.js
+++ b/js/echo_newline.js
@@ -98,7 +98,6 @@
         term.__get_prompt = term.get_prompt;
         term.exec = function() {
             last = null;
-            prompt = null;
             if (echo_command) {
                 this.settings().echoCommand = true;
             }
@@ -162,7 +161,7 @@
             }
         };
         term.get_prompt = function() {
-            return prompt || term.__get_prompt();
+            return last !== null ? prompt : term.__get_prompt();
         };
     }
 });

--- a/js/echo_newline.js
+++ b/js/echo_newline.js
@@ -70,9 +70,10 @@
                         term.echo_command();
                     }
                 } else {
-                    this.__echo(last + prompt + this.get_command());
+                    this.__echo(this.__get_prompt() + this.get_command());
                     this.__set_prompt(prompt);
                     last = null;
+                    prompt = null;
                 }
                 if (options && options.keymap && options.keymap.ENTER) {
                     options.keymap.ENTER.call(this, e, original);
@@ -141,17 +142,27 @@
                 } else {
                     term.__echo(arg, options);
                 }
-                prompt = null;
                 last = null;
+                prompt = null;
             }
             return term;
         };
         term.set_prompt = function(new_prompt) {
+            function wrapper(callback) {
+                function wrap_inner(result) {
+                    callback((last || "") + result);
+                }
+                new_prompt(wrap_inner);
+            }
             prompt = new_prompt;
-            term.__set_prompt((last || "") + prompt);
+            if (typeof new_prompt === "function") {
+                term.__set_prompt(wrapper);
+            } else {
+                term.__set_prompt((last || "") + prompt);
+            }
         };
         term.get_prompt = function() {
-            return last !== null ? prompt : term.__get_prompt();
+            return prompt || term.__get_prompt();
         };
     }
 });

--- a/js/echo_newline.js
+++ b/js/echo_newline.js
@@ -71,7 +71,7 @@
                     }
                 } else {
                     this.__echo(last + prompt + this.get_command());
-                    this.set_prompt(prompt);
+                    this.__set_prompt(prompt);
                     last = null;
                 }
                 if (options && options.keymap && options.keymap.ENTER) {
@@ -97,6 +97,7 @@
         term.__get_prompt = term.get_prompt;
         term.exec = function() {
             last = null;
+            prompt = null;
             if (echo_command) {
                 this.settings().echoCommand = true;
             }
@@ -149,12 +150,8 @@
             prompt = new_prompt;
             term.__set_prompt((last || "") + prompt);
         };
-        term.get_prompt = function(){
-            if(last === null){
-                return term.__get_prompt();
-            } else {
-                return prompt;
-            }
-        }
+        term.get_prompt = function() {
+            return last ? prompt : term.__get_prompt();
+        };
     }
 });

--- a/js/echo_newline.js
+++ b/js/echo_newline.js
@@ -144,5 +144,9 @@
             }
             return term;
         };
+        term.set_prompt = function(new_prompt) {
+            prompt = new_prompt;
+            term.__set_prompt((last || "") + prompt);
+        };
     }
 });


### PR DESCRIPTION
`echo_newline` currently does not get along with `set_prompt` very well.

For instance:
```js
function sleep(ms){
    return new Promise(resolve => setTimeout(resolve, ms));
}
term.set_prompt(">>>");
term.echo("hi", {newline : false});
await sleep(1000);
term.set_prompt(""); // "hi" disappears
await sleep(1000);
term.echo("hi", {newline : false}); // "hihi>>>"
await sleep(1000);
term.set_prompt(">>>"); // ">>>"
```
This fixes it by monkey patching set_prompt. It looks like this was supposed to be in there all along:
https://github.com/jcubic/jquery.terminal/blob/9c28d597e8295a5bd282030256a9fe1b50a371c1/js/echo_newline.js#L96