### PR TITLE
fix before_cursor not split \t when word=true

### DIFF
--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -9275,7 +9275,7 @@
             before_cursor: function(word) {
                 var pos = command_line.position();
                 var command = command_line.get().slice(0, pos);
-                var cmd_strings = command.split(' ');
+                var cmd_strings = command.split(/\s/);
                 var string; // string before cursor that will be completed
                 if (word) {
                     if (cmd_strings.length === 1) {


### PR DESCRIPTION
<!--

Thank you the PR, if you want your PR to be merged make sure you modify -src files and create PR against devel branch

-->
https://pyodide.org/en/latest/console.html
If you type
```py
for i in range(3):
    pri
```
and press tab, then `pri` will be completed to `print`.
However if the second line starts with \t (not 4 spaces), nothing will be completed.
This is because `before_cursor(true)` doesn't split by \t, so it returns `'\tpri'` here
https://github.com/jcubic/jquery.terminal/blob/d4fb4c1b29246f8ec55fe15fad4716a73e9dc456/js/jquery.terminal-src.js#L9327
thus makes this line fail
https://github.com/jcubic/jquery.terminal/blob/d4fb4c1b29246f8ec55fe15fad4716a73e9dc456/js/jquery.terminal-src.js#L9375