### PR TITLE
Add skippable typings

### DIFF
--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -8901,8 +8901,8 @@
                     var bottom = self.is_bottom();
                     var skipped = false;
                     $(document).bind('keyup.cmd', function(e) {
-                        //skip on enter
-                        if (e.which === 13) {
+                        //skip on "end"
+                        if (e.which === 35) {
                             skipped = true;
                         }
                     });

--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -8899,15 +8899,8 @@
                         self.set_prompt('');
                     }
                     var bottom = self.is_bottom();
-                    var skipped = false;
-                    $(document).bind('keyup.cmd', function(e) {
-                        //skip on "end"
-                        if (e.which === 35) {
-                            skipped = true;
-                        }
-                    });
                     var interval = setInterval(function() {
-                        if (!skipped) {
+                        if (!self.skip_event()) {
                             var chr = $.terminal
                                 .substring(formattted, char_i, char_i + 1);
                             if (options.mask) {
@@ -8937,7 +8930,6 @@
                                 finish_typing_fn(message, prompt, options);
                                 animating = false;
                             }, options.delay);
-                            $(document).unbind('keyup.cmd');
                         }
                     }, options.delay);
                 }
@@ -9622,6 +9614,36 @@
                     fire_event('onResume');
                 });
                 return self;
+            },
+            // -------------------------------------------------------------
+            // :: Skip the next terminal animations
+            // -------------------------------------------------------------
+            skip: function(num = 0, reset = true) {
+                if (reset) {
+                    self.skip_stop();
+                }
+                if (num >= 1) {
+                    skip_count = num;
+                } else {
+                    skip = true;
+                }
+            },
+            // -------------------------------------------------------------
+            // :: Evaluate if something should be skipped and count it
+            // -------------------------------------------------------------
+            skip_event: function() {
+                if (skip_count > 0) {
+                    skip_count--;
+                    return true;
+                }
+                return skip;
+            },
+            // -------------------------------------------------------------
+            // :: Stop skipping current terminal animations
+            // -------------------------------------------------------------
+            skip_stop: function() {
+                skip_count = 0;
+                skip = false;
             },
             // -------------------------------------------------------------
             // :: Return the number of characters that fit into the width of
@@ -11196,6 +11218,8 @@
         var logins = new Stack(); // stack of logins
         var command_queue = new DelayQueue();
         var animating = false; // true on typing animation
+        var skip = false; // true if skipping forever
+        var skip_count = 0; // number of skips chained
         var init_queue = new DelayQueue();
         var when_ready = ready(init_queue);
         var cmd_ready = ready(command_queue);

--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -7236,6 +7236,7 @@
         doubleTab: null,
         doubleTabEchoCommand: false,
         completion: false,
+        skipKey: 13,
         onInit: $.noop,
         onClear: $.noop,
         onBlur: $.noop,
@@ -8816,6 +8817,9 @@
             // then one terminal)
             var result, i;
             if (animating) {
+                if (e.which === settings.skipKey) {
+                    self.skip(1);
+                }
                 return false;
             }
             if (self.enabled()) {

--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -7236,7 +7236,6 @@
         doubleTab: null,
         doubleTabEchoCommand: false,
         completion: false,
-        skipKey: 13,
         onInit: $.noop,
         onClear: $.noop,
         onBlur: $.noop,
@@ -8817,9 +8816,6 @@
             // then one terminal)
             var result, i;
             if (animating) {
-                if (e.which === settings.skipKey) {
-                    self.skip();
-                }
                 return false;
             }
             if (self.enabled()) {
@@ -9631,6 +9627,12 @@
             // -------------------------------------------------------------
             skip_stop: function() {
                 skip = false;
+            },
+            // -------------------------------------------------------------
+            // :: Return if key animation is running
+            // -------------------------------------------------------------
+            animating: function() {
+                return animating;
             },
             // -------------------------------------------------------------
             // :: Return the number of characters that fit into the width of

--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -8899,22 +8899,37 @@
                         self.set_prompt('');
                     }
                     var bottom = self.is_bottom();
+                    var skipped = false;
+                    $(document).bind('keyup.cmd', function(e) {
+                        //skip on enter
+                        if (e.which === 13) {
+                            skipped = true;
+                        }
+                    });
                     var interval = setInterval(function() {
-                        var chr = $.terminal.substring(formattted, char_i, char_i + 1);
-                        if (options.mask) {
-                            var mask = command_line.mask();
-                            if (typeof mask === 'string') {
-                                chr = mask;
-                            } else if (mask) {
-                                chr = settings.maskChar;
+                        if (!skipped) {
+                            var chr = $.terminal
+                                .substring(formattted, char_i, char_i + 1);
+                            if (options.mask) {
+                                var mask = command_line.mask();
+                                if (typeof mask === 'string') {
+                                    chr = mask;
+                                } else if (mask) {
+                                    chr = settings.maskChar;
+                                }
                             }
+                            new_prompt += chr;
+                            self.set_prompt(new_prompt);
+                            if (chr === '\n' && bottom) {
+                                self.scroll_to_bottom();
+                            }
+                            char_i++;
+                        } else {
+                            var chrRest = $.terminal.substring(formattted, char_i, len);
+                            new_prompt += chrRest;
+                            self.set_prompt(new_prompt);
+                            char_i = len;
                         }
-                        new_prompt += chr;
-                        self.set_prompt(new_prompt);
-                        if (chr === '\n' && bottom) {
-                            self.scroll_to_bottom();
-                        }
-                        char_i++;
                         if (char_i === len) {
                             clearInterval(interval);
                             setTimeout(function() {
@@ -8922,6 +8937,7 @@
                                 finish_typing_fn(message, prompt, options);
                                 animating = false;
                             }, options.delay);
+                            $(document).unbind('keyup.cmd');
                         }
                     }, options.delay);
                 }

--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -8818,7 +8818,7 @@
             var result, i;
             if (animating) {
                 if (e.which === settings.skipKey) {
-                    self.skip(1);
+                    self.skip();
                 }
                 return false;
             }
@@ -8904,7 +8904,7 @@
                     }
                     var bottom = self.is_bottom();
                     var interval = setInterval(function() {
-                        if (!self.skip_event()) {
+                        if (!skip) {
                             var chr = $.terminal
                                 .substring(formattted, char_i, char_i + 1);
                             if (options.mask) {
@@ -8922,6 +8922,7 @@
                             }
                             char_i++;
                         } else {
+                            self.skip_stop();
                             var chrRest = $.terminal.substring(formattted, char_i, len);
                             new_prompt += chrRest;
                             self.set_prompt(new_prompt);
@@ -9622,31 +9623,13 @@
             // -------------------------------------------------------------
             // :: Skip the next terminal animations
             // -------------------------------------------------------------
-            skip: function(num = 0, reset = true) {
-                if (reset) {
-                    self.skip_stop();
-                }
-                if (num >= 1) {
-                    skip_count = num;
-                } else {
-                    skip = true;
-                }
+            skip: function() {
+                skip = true;
             },
             // -------------------------------------------------------------
-            // :: Evaluate if something should be skipped and count it
-            // -------------------------------------------------------------
-            skip_event: function() {
-                if (skip_count > 0) {
-                    skip_count--;
-                    return true;
-                }
-                return skip;
-            },
-            // -------------------------------------------------------------
-            // :: Stop skipping current terminal animations
+            // :: Stop skipping the next terminal animations
             // -------------------------------------------------------------
             skip_stop: function() {
-                skip_count = 0;
                 skip = false;
             },
             // -------------------------------------------------------------
@@ -11222,8 +11205,7 @@
         var logins = new Stack(); // stack of logins
         var command_queue = new DelayQueue();
         var animating = false; // true on typing animation
-        var skip = false; // true if skipping forever
-        var skip_count = 0; // number of skips chained
+        var skip = false; // true if skipping currently
         var init_queue = new DelayQueue();
         var when_ready = ready(init_queue);
         var cmd_ready = ready(command_queue);


### PR DESCRIPTION
This makes typing animations skippable by hitting enter while they are running.

I selected ~~enter because of convenience~~ and `keyup` in order to not interfere with other bindings. However, if you see another, better fitting/cleaner binding it should be easy to switch it. (I thought of `dblclick` for minimal interference as well, but its a bit too inconvenient imho)

I initially worked on master, without the masking fix #770 . In the "skipping" case this might still be a problem.
