### PR TITLE
Fix type for enter

### DIFF
--- a/js/jquery.terminal.d.ts
+++ b/js/jquery.terminal.d.ts
@@ -792,7 +792,7 @@ interface JQueryTerminal<TElement = HTMLElement> extends JQuery<TElement> {
     set_position(pos: number, relative?: boolean): JQueryTerminal;
     get_position(): number;
     enter(str: string, options: JQueryTerminal.animationOptions): JQuery.Promise<void>;
-    enter(str: string): JQueryTerminal;
+    enter(str?: string): JQueryTerminal;
     insert(str: string, options: JQueryTerminal.insertOptions & JQueryTerminal.animationOptions): JQuery.Promise<void>;
     insert(str: string, stay?: boolean): JQueryTerminal;
     set_prompt(prompt: JQueryTerminal.ExtendedPrompt, options: JQueryTerminal.animationOptions): JQuery.Promise<void>;


### PR DESCRIPTION
<!--

Thank you the PR, if you want your PR to be merged make sure you modify -src files and create PR against devel branch

-->

This enables me to use `term.enter()` without `// @ts-ignore`.