### PR TITLE
Don't ignore `completionEscape` option when using `autocompleteMenu`

### DIFF
--- a/js/autocomplete_menu.js
+++ b/js/autocomplete_menu.js
@@ -105,7 +105,7 @@
                 }
             }
             if (e.which === 9) {
-                if (term.complete(matched)) {
+                if (term.complete(matched, {escape: completionEscape})) {
                     word = term.before_cursor(true);
                     regex = new RegExp('^' + $.terminal.escape_regex(word));
                 }
@@ -126,6 +126,7 @@
             var onInit = settings.onInit || $.noop;
             var keydown = settings.keydown || $.noop;
             var completion = settings.completion;
+            var completionEscape = settings.completionEscape;
             delete settings.completion;
             settings.onInit = function(term) {
                 onInit.call(this, term);


### PR DESCRIPTION
Hi, I noticed that when `autocompleteMenu` is `true`, the `completionEscape` parameter is ignored when using the `TAB` key to complete. This happens because `autocomplete_menu.js` doesn't correctly pass this option down to the `complete(...)` function

Here we get the `completionEscape` setting and then pass it to the terminal's `complete(...)` function, as in [this example](https://github.com/jcubic/leash/blob/e0a7a9fbd5e30daa97711b5b5c1ff33c6f485fbb/lib/jquery.terminal-src.js#L5244). This fixes the issue and lets us use the `completionEscape` option with `autocompleteMenu`