### PR TITLE
fix: typing of terminalObjectFunction (this)

### DIFF
--- a/js/jquery.terminal.d.ts
+++ b/js/jquery.terminal.d.ts
@@ -22,7 +22,7 @@ type TypeOrPromise<T> = T | PromiseLike<T>;
 
 declare namespace JQueryTerminal {
     type interpreterFunction = (this: JQueryTerminal, command: string, term: JQueryTerminal) => any;
-    type terminalObjectFunction = (...args: (string | number | RegExp)[]) => (void | TypeOrPromise<simpleEchoValue>);
+    type terminalObjectFunction = (this: JQueryTerminal, ...args: (string | number | RegExp)[]) => (void | TypeOrPromise<simpleEchoValue>);
     type Interpreter = string | interpreterFunction | ObjectInterpreter;
     type ObjectInterpreter = {
         [key: string]: ObjectInterpreter | terminalObjectFunction;

--- a/test.ts
+++ b/test.ts
@@ -47,6 +47,11 @@ $('.term').terminal([obj_interpreter]);
 $('.term').terminal(["foo.php", obj_interpreter]);
 $('.term').terminal(["foo.php", obj_interpreter, function(command) {
 }]);
+$('.term').terminal({
+    help: function () {
+        this.echo('Help command');
+    }
+});
 
 class Foo {
     x: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "target": "es6",
         "module": "commonjs",
-        "lib": ["es2015", "ES2018.Promise", "dom"]
+        "lib": ["es2015", "ES2018.Promise", "dom"],
+        "noImplicitThis": true
     },
     "exclude": ["npm"]
 }


### PR DESCRIPTION
The PR instructions say to make the PR against the devel branch, but that branch seems behind master. I was thinking it would be simpler for you to target master for the merge :)

This PR is a super simple change in a typing, not to have typing errors in the hello world example from [this article](https://itnext.io/how-to-create-interactive-terminal-like-website-888bb0972288) (type `this`).