### PR TITLE
fix: typing error ``jquery.terminal`` is not a module

### DIFF
--- a/js/jquery.terminal.d.ts
+++ b/js/jquery.terminal.d.ts
@@ -828,3 +828,8 @@ interface JQueryTerminal<TElement = HTMLElement> extends JQuery<TElement> {
     scroll_to_bottom(): JQueryTerminal;
     is_bottom(): boolean;
 }
+
+declare module 'jquery.terminal' {
+    const JQTerminal: (window: Window, JQuery: JQueryStatic) => void;
+    export default JQTerminal;
+}


### PR DESCRIPTION
Fix for type error when ``import terminal from 'jquery.terminal'`` you got the error: 
```console
File '[.../node_modules/jquery.terminal/js/jquery.terminal.d.ts' is not a module.
```

Possible fix for issues:
https://github.com/jcubic/jquery.terminal/issues/844
https://github.com/jcubic/jquery.terminal/issues/849#issuecomment-1526128024
