### PR TITLE
Add Ctrl+backspace to default keymap

### DIFF
--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -2498,6 +2498,7 @@
             'SHIFT+INSERT': paste_event,
             'CTRL+SHIFT+T': return_true, // open closed tab
             'CTRL+W': delete_backward({clipboard: true, hold: false}),
+            'CTRL+BACKSPACE': delete_backward({clipboard: true, hold: false}),
             'HOLD+BACKSPACE': delete_backward({clipboard: false, hold: true}),
             'HOLD+SHIFT+BACKSPACE': delete_backward({clipboard: false, hold: true}),
             'CTRL+H': function() {

--- a/templates/Makefile.in
+++ b/templates/Makefile.in
@@ -21,7 +21,7 @@ COMMIT=`git log -n 1 | grep '^commit' | sed 's/commit //'`
 TOKEN=cat .github.token | tr -d '\n'
 URL=`git config --get remote.origin.url`
 skip_re="[xfi]it\\(|[fdx]describe\\("
-UPDATE_CONTRIBUTORS=0
+UPDATE_CONTRIBUTORS=1
 
 .PHONY: coverage test coveralls lint.src eslint skipped_tests jsonlint publish lint tscheck publish-guthub emoji
 


### PR DESCRIPTION
Implements feature proposed in #920. The shortcut is added ex-novo to the default keymap, without any remapping.
The shortcut should work on most if not all desktop web browsers since `Ctrl + backspace` is not usually mapped to any browser-specific action.
