### PR TITLE
fix typo in css/jquery.terminal.css causing minification warning

### DIFF
--- a/css/jquery.terminal.css
+++ b/css/jquery.terminal.css
@@ -23,7 +23,7 @@
 }
 .cmd .cmd-clipboard {
     position: absolute !important;
-    let: -16px;
+    left: -16px;
     left: calc(-16px / var(--pixel-density, 1)) !important;
     top: 0 !important;
     width: 16px;


### PR DESCRIPTION
Found this typo when building the project. Could you please check?

![image](https://github.com/user-attachments/assets/f3d139b9-395c-4902-a7db-8bb444aab160)

Thank you 👍 
