### PR TITLE
fix caret error on empty selection when copying with CTRL+C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.4.6.1
 ### Bugfix
 * fix mobile detection [#1047](https://github.com/jcubic/jquery.terminal/issues/1047)
+* fix caret error on empty selection when copying with CTRL+C [#1048](https://github.com/jcubic/jquery.terminal/issues/1048)
 
 ## 2.46.0
 ### Breaking

--- a/__tests__/terminal.spec.js
+++ b/__tests__/terminal.spec.js
@@ -917,6 +917,13 @@ describe('Terminal utils', function() {
             expect($.terminal.escape_regex('\\^*+?.$[]{}()')).toEqual(safe);
         });
     });
+    describe('$.fn.caret', function() {
+        it('should not throw on empty selection', function() {
+            expect(function() {
+                $('#caret-missing-node').caret();
+            }).not.toThrow();
+        });
+    });
     describe('$.terminal.have_formatting', function() {
         var formattings = [
             'some text [[;;]Te[xt] and formatting',

--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -908,6 +908,9 @@
     /* istanbul ignore next */
     $.fn.caret = function(pos) {
         var target = this[0];
+        if (!target) {
+            return arguments.length === 0 ? 0 : this;
+        }
         var isContentEditable = target.contentEditable === 'true';
         //get
         if (arguments.length === 0) {


### PR DESCRIPTION
<!--

Thank you for the PR, if you want your PR to be merged make sure you modify -src files and create PR against devel branch

-->

`$.fn.caret` reads `this[0].contentEditable` without checking that the set has an element, so calling it on an empty selection throws `Cannot read properties of undefined (reading 'contentEditable')`. This is the crash from #1048, where pressing CTRL+C reaches `text_to_clipboard` with a `textarea` lookup that came back empty. Added an early return so caret is a no-op on an empty set and a test that covers it.

Fixes #1048
