### PR TITLE
Keep multiline cursor navigation within command bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.47.1
+### Bugfix
+* keep down-arrow navigation within the command for multiline emoji input [#1050](https://github.com/jcubic/jquery.terminal/issues/1050)
+
 ## 2.47.0
 ### Breaking
 * echo command echoes a string again (revert of 2.46.0), so the command no longer appears as a function in `export_view`

--- a/__tests__/terminal.spec.js
+++ b/__tests__/terminal.spec.js
@@ -4562,6 +4562,15 @@ describe('Terminal plugin', function() {
             cmd.position(0);
             expect(cmd.position()).toEqual(0);
         });
+        it('should clamp relative position', function() {
+            cmd.set('foo');
+            cmd.position(0);
+            cmd.position(-1, true);
+            expect(cmd.position()).toEqual(0);
+            cmd.position(3);
+            cmd.position(1, true);
+            expect(cmd.position()).toEqual(3);
+        });
         it('should set and remove mask', function() {
             cmd.set('foobar').position(0);
             term.focus();
@@ -4725,6 +4734,78 @@ describe('Terminal plugin', function() {
             up();
             positions.push(cmd.position());
             expect(positions).toMatchSnapshot();
+        });
+        it('should navigate a line with n - 1 characters (#1050)', function() {
+            var command = 'x'.repeat(term.cols() - 1);
+            term.focus();
+            cmd.set(command);
+            cmd.position(command.length);
+            shortcut(false, false, false, 37, 'arrowleft');
+            expect(cmd.position()).toEqual(command.length - 1);
+            cmd.position(command.length - 1);
+            shortcut(false, false, false, 39, 'arrowright');
+            expect(cmd.position()).toEqual(command.length);
+            cmd.position(command.length);
+            shortcut(false, false, false, 38, 'arrowup');
+            expect(cmd.position()).toEqual(0);
+            cmd.position(0);
+            shortcut(false, false, false, 40, 'arrowdown');
+            expect(cmd.position()).toEqual(0);
+            expect(cmd.get()).toEqual(command);
+        });
+        it('should navigate two lines (#1050)', function() {
+            var command = 'abcd\nefgh';
+            term.focus();
+            cmd.set(command);
+            cmd.position(2);
+            shortcut(false, false, false, 37, 'arrowleft');
+            expect(cmd.position()).toEqual(1);
+            cmd.position(2);
+            shortcut(false, false, false, 39, 'arrowright');
+            expect(cmd.position()).toEqual(3);
+            cmd.position(7);
+            shortcut(false, false, false, 38, 'arrowup');
+            expect(cmd.position()).toEqual(0);
+            cmd.position(2);
+            shortcut(false, false, false, 40, 'arrowdown');
+            expect(cmd.position()).toEqual(command.length);
+            expect(cmd.get()).toEqual(command);
+        });
+        it('should navigate three lines (#1050)', function() {
+            var command = 'abcd\nefgh\nijkl';
+            term.focus();
+            cmd.set(command);
+            cmd.position(12);
+            shortcut(false, false, false, 37, 'arrowleft');
+            expect(cmd.position()).toEqual(11);
+            cmd.position(11);
+            shortcut(false, false, false, 39, 'arrowright');
+            expect(cmd.position()).toEqual(12);
+            cmd.position(12);
+            shortcut(false, false, false, 38, 'arrowup');
+            expect(cmd.position()).toEqual(7);
+            cmd.position(7);
+            shortcut(false, false, false, 40, 'arrowdown');
+            expect(cmd.position()).toEqual(12);
+            expect(cmd.get()).toEqual(command);
+        });
+        it('should navigate emoji across lines (#1050)', function() {
+            var command = 'a\u263a\ufe0fb\nc\u263a\ufe0fd';
+            term.focus();
+            cmd.set(command);
+            cmd.position(3);
+            shortcut(false, false, false, 37, 'arrowleft');
+            expect(cmd.position()).toEqual(2);
+            cmd.position(3);
+            shortcut(false, false, false, 39, 'arrowright');
+            expect(cmd.position()).toEqual(4);
+            cmd.position(8);
+            shortcut(false, false, false, 38, 'arrowup');
+            expect(cmd.position()).toEqual(1);
+            cmd.position(3);
+            shortcut(false, false, false, 40, 'arrowdown');
+            expect(cmd.position()).toEqual(command.length);
+            expect(cmd.get()).toEqual(command);
         });
     });
     function AJAXMock(url, response, options) {

--- a/js/jquery.terminal-src.js
+++ b/js/jquery.terminal-src.js
@@ -4060,8 +4060,9 @@
                     var pos = position;
                     var len = bare_text(command).length;
                     if (relative) {
-                        position += n;
-                    } else if (n < 0) {
+                        n += position;
+                    }
+                    if (n < 0) {
                         position = 0;
                     } else if (n > len) {
                         position = len;


### PR DESCRIPTION
Closes #1050

## Summary

- cover n - 1, two-line, three-line, and emoji commands with all four arrow keys
- clamp relative cursor movement inside the existing position setter
- record the multiline emoji navigation fix in the changelog

## Verification

- focused issue and relative-bound tests: 5 passed
- complete Jest suite: 552 passed, 77 snapshots passed
- ESLint, JSONLint, skipped-test check, and TypeScript check
- full build with the repository make targets
- git diff --check
